### PR TITLE
Mongo authentication

### DIFF
--- a/src/java/grails/plugins/mongodb/MongoHolderBean.java
+++ b/src/java/grails/plugins/mongodb/MongoHolderBean.java
@@ -65,10 +65,16 @@ public class MongoHolderBean {
     }
 
     morphia = new Morphia();
-    datastore = (DatastoreImpl)morphia.createDatastore(mongo, database);
+    String username = getConfigVar(flatConfig,"mongodb.username",null);
+    char[] password = getCharArray(getConfigVar(flatConfig, "mongodb.password", null));
+    datastore = (DatastoreImpl)morphia.createDatastore(mongo, database,username,password);
 
     // init ObjectFactory
     morphia.getMapper().getOptions().objectFactory = new MongoDomainObjectFactory(application);
+  }
+
+  private char[] getCharArray(String configVar) {
+      return configVar == null ? null : configVar.toCharArray();
   }
 
   private String getConfigVar(Map config, String key, String defaultValue) {


### PR DESCRIPTION
Here is a small patch to allow plugin to be configured with a username/password for servers running with --auth.  Morphia ignores the username when null is passed.

Thanks for the great plugin. My first experience with Mongo was (almost) painless with this plugin and Morphia. 
